### PR TITLE
Fix: wrong root dir link

### DIFF
--- a/handsdown/settings.py
+++ b/handsdown/settings.py
@@ -7,7 +7,7 @@ from pathlib import Path
 HANDSDOWN_PATH = Path(__file__)
 
 # Path to `assets` directory from root.
-ASSETS_PATH = HANDSDOWN_PATH / "assets"
+ASSETS_PATH = HANDSDOWN_PATH.parent / "assets"
 
 # Global `logging.Logger` name.
 LOGGER_NAME = "handsdown"


### PR DESCRIPTION
Fixes:
`FileNotFoundError: [Errno 2] No such file or directory: 'O:\\Python\\lib\\site-packages\\handsdown\\settings.py\\assets\\gh_pages_config.yml'`
that appears after:
`handsdown --external https://github.com/alchem1ster/<my_repository_name>/`
OS: Windows 10 Professional 21H2
Python version: 3.8.10
Handsdown version: 0.4.2 (installed via pip)